### PR TITLE
FlushCommand: add check for symbolic links

### DIFF
--- a/commands/FlushCommand.php
+++ b/commands/FlushCommand.php
@@ -72,7 +72,7 @@ class FlushCommand extends CConsoleCommand
                     continue;
                 }
                 $entryPath = $path . '/' . $entry;
-                if (is_dir($entryPath)) {
+                if (!is_link($entryPath) && is_dir($entryPath)) {
                     $this->flushDirectory($entryPath, true);
                 } else {
                     unlink($entryPath);


### PR DESCRIPTION
Follow symlinks may cause deleting files outside of the flushing directory. Besides of that symlinks are subjects to `unlink` rather than `rmdir`.
